### PR TITLE
Added enum level selection to scene control

### DIFF
--- a/Levels/LevelBox.tscn
+++ b/Levels/LevelBox.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=11 format=2]
 
-[ext_resource path="res://Music/mus_generigroove.wav" type="AudioStream" id=1]
-[ext_resource path="res://Scripts/RotatingLight.gd" type="Script" id=2]
-[ext_resource path="res://Scripts/Level.gd" type="Script" id=3]
-[ext_resource path="res://Objects/PlayerDrone.tscn" type="PackedScene" id=4]
-[ext_resource path="res://Scripts/PickupCube.gd" type="Script" id=5]
-[ext_resource path="res://Blender/companionCubeMaterial.material" type="Material" id=6]
-[ext_resource path="res://Font/BloodDroneFont.tres" type="DynamicFont" id=7]
-[ext_resource path="res://Objects/Conveyer.tscn" type="PackedScene" id=8]
+[ext_resource path="res://Objects/SceneControl.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Objects/PlayerDrone.tscn" type="PackedScene" id=2]
+[ext_resource path="res://Scripts/PickupCube.gd" type="Script" id=3]
+[ext_resource path="res://Blender/companionCubeMaterial.material" type="Material" id=4]
+[ext_resource path="res://Font/BloodDroneFont.tres" type="DynamicFont" id=5]
+[ext_resource path="res://Objects/Conveyer.tscn" type="PackedScene" id=6]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 1.5, 4, 1.5 )
@@ -22,7 +20,7 @@ surfaces/0 = {
 "blend_shape_data": [  ],
 "format": 97559,
 "index_count": 36,
-"material": ExtResource( 6 ),
+"material": ExtResource( 4 ),
 "primitive": 4,
 "skeleton_aabb": [  ],
 "vertex_count": 24
@@ -41,37 +39,11 @@ surfaces/0 = {
 "vertex_count": 24
 }
 
-[node name="LevelBox" type="Spatial"]
+[node name="Level" type="Spatial"]
 
-[node name="Scene Control" type="Node" parent="."]
+[node name="SceneControl" parent="." instance=ExtResource( 1 )]
 
-[node name="InterpolatedCamera" type="InterpolatedCamera" parent="Scene Control"]
-transform = Transform( 1, 0, 0, 0, 0.866026, 0.5, 0, -0.5, 0.866026, 0, 20, 30 )
-keep_aspect = 0
-current = true
-target = NodePath("../../PlayerDrone/CameraTarget")
-speed = 2.0
-enabled = true
-
-[node name="Music" type="AudioStreamPlayer" parent="Scene Control"]
-stream = ExtResource( 1 )
-volume_db = -20.0
-
-[node name="Sound Effects" type="AudioStreamPlayer" parent="Scene Control"]
-stream = ExtResource( 1 )
-volume_db = -20.0
-
-[node name="DirectionalLight" type="DirectionalLight" parent="Scene Control"]
-transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 16, 3 )
-light_indirect_energy = 6.0
-shadow_enabled = true
-shadow_bias = 2.0
-script = ExtResource( 2 )
-
-[node name="FloorSpawner" type="Spatial" parent="Scene Control"]
-script = ExtResource( 3 )
-
-[node name="PlayerDrone" parent="." instance=ExtResource( 4 )]
+[node name="PlayerDrone" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0 )
 
 [node name="Body" parent="PlayerDrone" index="1"]
@@ -95,7 +67,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.5, 0, 0 )
 editor/display_folded = true
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 4, 0 )
 can_sleep = false
-script = ExtResource( 5 )
+script = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="PickupCube"]
 shape = SubResource( 2 )
@@ -121,7 +93,7 @@ margin_top = 5.36035
 margin_right = 867.0
 margin_bottom = 53.3604
 rect_scale = Vector2( 2, 2 )
-custom_fonts/font = ExtResource( 7 )
+custom_fonts/font = ExtResource( 5 )
 pressed = true
 text = "Show ID"
 
@@ -133,9 +105,11 @@ margin_bottom = 163.0
 max_length = 4
 placeholder_text = "ENTER ID"
 
-[node name="Conveyer" parent="." instance=ExtResource( 8 )]
+[node name="Conveyer" parent="." instance=ExtResource( 6 )]
 transform = Transform( 2, 0, 0, 0, 2, 0, 0, 0, 2, 8, 2, 0 )
 [connection signal="body_entered" from="PlayerDrone/Body/PlayerPickup" to="PickupCube" method="_on_PlayerPickup_body_entered"]
 [connection signal="body_exited" from="PlayerDrone/Body/PlayerPickup" to="PickupCube" method="_on_PlayerPickup_body_exited"]
+
+[editable path="SceneControl"]
 
 [editable path="PlayerDrone"]

--- a/Objects/PlayerDrone.tscn
+++ b/Objects/PlayerDrone.tscn
@@ -69,7 +69,7 @@ light_color = Color( 1, 0.4, 1, 1 )
 light_energy = 2.16
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 6, 0 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-008, 1, 0, -1, -4.37114e-008, 0, 6, 0 )
 light_color = Color( 1, 0.4, 1, 1 )
 light_energy = 0.22
 light_indirect_energy = 0.0

--- a/Objects/SceneControl.tscn
+++ b/Objects/SceneControl.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://Scripts/SceneControl.gd" type="Script" id=1]
+[ext_resource path="res://Music/mus_generigroove.wav" type="AudioStream" id=2]
+[ext_resource path="res://Scripts/RotatingLight.gd" type="Script" id=3]
+[ext_resource path="res://Scripts/Level.gd" type="Script" id=4]
+
+[node name="Scene Control" type="Node"]
+script = ExtResource( 1 )
+
+[node name="InterpolatedCamera" type="InterpolatedCamera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.866026, 0.5, 0, -0.5, 0.866026, 0, 20, 30 )
+keep_aspect = 0
+current = true
+target = NodePath("../../PlayerDrone/CameraTarget")
+speed = 2.0
+enabled = true
+
+[node name="Music" type="AudioStreamPlayer" parent="."]
+stream = ExtResource( 2 )
+volume_db = -20.0
+
+[node name="Sound Effects" type="AudioStreamPlayer" parent="."]
+stream = ExtResource( 2 )
+volume_db = -20.0
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 16, 3 )
+light_indirect_energy = 6.0
+shadow_enabled = true
+shadow_bias = 2.0
+script = ExtResource( 3 )
+
+[node name="FloorSpawner" type="Spatial" parent="."]
+script = ExtResource( 4 )

--- a/Objects/SceneControl.tscn
+++ b/Objects/SceneControl.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://Scripts/RotatingLight.gd" type="Script" id=3]
 [ext_resource path="res://Scripts/Level.gd" type="Script" id=4]
 
-[node name="Scene Control" type="Node"]
+[node name="SceneControl" type="Node"]
 script = ExtResource( 1 )
 
 [node name="InterpolatedCamera" type="InterpolatedCamera" parent="."]

--- a/Scripts/DroneFace.gd
+++ b/Scripts/DroneFace.gd
@@ -1,11 +1,12 @@
 extends Spatial
 export var headBob = 0.1
 onready var droneBody = get_node("../Body")
+onready var sceneControl = get_node("/root/Level/SceneControl/")
 
 func _ready():
 	
-	match(get_owner().get_parent().get_name()):
-		"LevelBox":
+	match(sceneControl.level):
+		0: #LevelBox
 			print("Current level is LevelBox.")
 			var IDToggle = get_node("../../UI/IDToggle")
 			var IDAssign = get_node("../../UI/IDAssign")
@@ -13,7 +14,7 @@ func _ready():
 			IDAssign.connect("text_changed",self,"assign_id")
 			print("LevelBox UI elements assigned to PlayerDrone's face.")
 			
-		_:
+		_: #Default
 			print("The PlayerDrone is in an unfamiliar level. Failed to associate UI elements.")
 			print(get_owner().get_parent().get_name())
 

--- a/Scripts/SceneControl.gd
+++ b/Scripts/SceneControl.gd
@@ -1,0 +1,4 @@
+extends Node
+
+enum LEVEL_LIST { LevelBox, LevelTest, SomeOtherSelection }
+export(LEVEL_LIST) var level = LEVEL_LIST.LevelBox


### PR DESCRIPTION
This update changes the way the SceneControl node works for better compatibility with the rest of the project.

-It is now renamed "SceneControl" (no space) so it can be easier accessed via absolute path in code. (i.e "/root/Level/SceneControl/"
-The SceneControl node now has a script attached which exports an enum of level names to the inspector pane. This allows us to select what level the SceneControl is in charge of from a predetermined list.
-The SceneControl node (and its children) has been saved as an instanced object so it can be reused in other levels.
-Because of the enumerated level selection, the root node of the LevelBox level (and ideally all future levels) can be renamed to just "Level" without fear of confusion. This, again, allows for object access code to easily be reused across levels (i.e a drone can always store a reference to SceneControl by looking for the node at /root/Level/SceneControl/ since the Level root node will always have the same name from now on).
-The DroneFace.gd script has been updated to support enumeration when linking up UI signal emitters and recievers.
-The LevelBox file has been updated automatically due to changes in its node structure.