### PR TITLE
New and improved camera on SceneControl

### DIFF
--- a/Objects/SceneControl.tscn
+++ b/Objects/SceneControl.tscn
@@ -1,20 +1,13 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Scripts/SceneControl.gd" type="Script" id=1]
 [ext_resource path="res://Music/mus_generigroove.wav" type="AudioStream" id=2]
 [ext_resource path="res://Scripts/RotatingLight.gd" type="Script" id=3]
 [ext_resource path="res://Scripts/Level.gd" type="Script" id=4]
+[ext_resource path="res://Scripts/DynamicCamera.gd" type="Script" id=5]
 
 [node name="SceneControl" type="Node"]
 script = ExtResource( 1 )
-
-[node name="InterpolatedCamera" type="InterpolatedCamera" parent="."]
-transform = Transform( 1, 0, 0, 0, 0.866026, 0.5, 0, -0.5, 0.866026, 0, 20, 30 )
-keep_aspect = 0
-current = true
-target = NodePath("../../PlayerDrone/CameraTarget")
-speed = 2.0
-enabled = true
 
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 2 )
@@ -33,3 +26,6 @@ script = ExtResource( 3 )
 
 [node name="FloorSpawner" type="Spatial" parent="."]
 script = ExtResource( 4 )
+
+[node name="Camera" type="Camera" parent="."]
+script = ExtResource( 5 )

--- a/Scripts/DynamicCamera.gd
+++ b/Scripts/DynamicCamera.gd
@@ -1,0 +1,19 @@
+extends Camera
+
+onready var playerDrone = get_node("/root/Level/PlayerDrone/")
+onready var floorSpawner = get_node("/root/Level/SceneControl/FloorSpawner")
+onready var space_state = get_world().direct_space_state
+
+var offset = Vector3(0,0,10)
+var raycastResult
+
+func _process(delta):
+	#Set camera to drone's position + offset.
+	translation = playerDrone.translation + offset
+	
+	#Cast a ray to see if there's anything in the way.
+	raycastResult = space_state.intersect_ray(playerDrone.translation, translation, [self, playerDrone])
+	
+	#If there is something in the way, move the camera to the intersection.
+	if(raycastResult):
+		translation = raycastResult.position 


### PR DESCRIPTION
This unit has added a new camera to the SceneControl object, replacing the somewhat immutable interpolated camera.

-The new camera derives its position every frame by getting the player drone's position and applying an offset so it is always in front of the drone.
-A ray is then cast from the drone to the camera. If the ray intersects with something (if something is in the way of the drone and the camera) the camera is moved to the point of collision so it is always in front of any object that would otherwise block the camera's view.

Since this is a further addition to the SceneControl upgrade from the "refactorLevelSelection" branch, I thought it'd be wise to merge this branch down into that, then merge the refactored level select branch into master, but I'm not sure what the best practice for this would usually be.