### PR TITLE
Camera now tilts and offsets vertically as the player approaches a wall

### DIFF
--- a/Scripts/Conveyer.gd
+++ b/Scripts/Conveyer.gd
@@ -9,7 +9,6 @@ func _ready():
 	var foo = $Collision/Mesh.mesh.surface_get_material(1);
 	var bar = $Collision/Mesh.mesh.surface_get_material(1);
 	var heck = $Collision/Mesh.mesh.surface_get_material(2);
-	print(foo.get_property_list())
 	foo.flags_vertex_lighting = true;
 
 func _process(delta):

--- a/Scripts/DynamicCamera.gd
+++ b/Scripts/DynamicCamera.gd
@@ -1,19 +1,34 @@
 extends Camera
 
 onready var playerDrone = get_node("/root/Level/PlayerDrone/")
-onready var floorSpawner = get_node("/root/Level/SceneControl/FloorSpawner")
 onready var space_state = get_world().direct_space_state
 
-var offset = Vector3(0,0,10)
+var MIN_OFFSET_HEIGHT = 0
+export var MAX_OFFSET_HEIGHT = 4
+export var MAX_DOWNWARD_TILT = -60
+export var DISTANCE_FROM_DRONE = 10
+
+var offset = Vector3(0,0,DISTANCE_FROM_DRONE)
+var collision_avoidance_offset = Vector3(0,0,-0.1)
 var raycastResult
 
 func _process(delta):
-	#Set camera to drone's position + offset.
-	translation = playerDrone.translation + offset
 	
-	#Cast a ray to see if there's anything in the way.
-	raycastResult = space_state.intersect_ray(playerDrone.translation, translation, [self, playerDrone])
+	#Cast a ray to see if there's anything in the way of the camera.
+	raycastResult = space_state.intersect_ray(playerDrone.translation, playerDrone.translation + offset, [self, playerDrone])
 	
 	#If there is something in the way, move the camera to the intersection.
 	if(raycastResult):
-		translation = raycastResult.position 
+		translation = raycastResult.position + collision_avoidance_offset
+		translation.y += lerp(MAX_OFFSET_HEIGHT, MIN_OFFSET_HEIGHT, (raycastResult.position.z - playerDrone.translation.z) / 10) 
+	#If not, just offset the camera from the drone's position.
+	else:
+		translation = playerDrone.translation + offset
+		
+	#Then, point the camera at the drone.
+	look_at(playerDrone.translation, Vector3(0,1,0))
+	
+	#But reel it back if the camera is tilting too far downward.
+	if(rotation_degrees.x < MAX_DOWNWARD_TILT):
+		rotation_degrees.x = MAX_DOWNWARD_TILT
+	


### PR DESCRIPTION
The camera script has been updated. Now when there's a ray collision, the script calculates the player's distance from the point of collision and uses that to interpolate a value between the min and max vertical offset. It also points itself towards the drone every frame, which, combined with a height offset, allows it to tilt as the player approaches it.

I've also removed the get_property_list() call from the conveyer script because it takes up the console's text buffer and I shouldn't have left it in in the first place.