### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+
+# Godot-specific ignores
+.import/
+*.import
+*.md5
+export.cfg
+export_presets.cfg
+
+# Mono-specific ignores
+.mono/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .import/
 *.import
 *.md5
+Blender/*.import
+Blender/*.md5
 export.cfg
 export_presets.cfg
 


### PR DESCRIPTION
In order to reduce merge conflicts, we should add a .gitignore file so all the unnecessary files such as the .import and .md5 files are no longer tracked.

The import files seem machine-dependant, with a unique hash for each. This means they shouldn't be shared between computers and definitely not included in any pull requests.