### PR TITLE
Camera moves differently, walls generate differently

### DIFF
--- a/Objects/Tiles/BasicWall.tscn
+++ b/Objects/Tiles/BasicWall.tscn
@@ -18,14 +18,12 @@ surfaces/0 = {
 "vertex_count": 24
 }
 
-[node name="North" type="StaticBody"]
-editor/display_folded = true
+[node name="Wall" type="StaticBody"]
 transform = Transform( 2, 0, 0, 0, 4, 0, 0, 0, 0.3, 0, 4.3, -2.3 )
 
-[node name="NorthCollision" type="CollisionShape" parent="."]
-editor/display_folded = true
+[node name="Collision" type="CollisionShape" parent="."]
 shape = SubResource( 1 )
 
-[node name="NorthMesh" type="MeshInstance" parent="NorthCollision"]
+[node name="Mesh" type="MeshInstance" parent="Collision"]
 mesh = SubResource( 2 )
 material/0 = null

--- a/Scripts/DynamicCamera.gd
+++ b/Scripts/DynamicCamera.gd
@@ -7,10 +7,12 @@ export var MIN_OFFSET_HEIGHT = 0
 export var MAX_OFFSET_HEIGHT = 4
 export var DISTANCE_FROM_DRONE = 10
 
-var offset = Vector3(0,0,DISTANCE_FROM_DRONE)
+var offset = Vector3(0,0,0)
 var raycastResult
 
 func _process(delta):
+	
+	offset = Vector3(0,0,DISTANCE_FROM_DRONE)
 	
 	#Set the camera position to the drone's position with an offset.
 	translation = playerDrone.translation + offset

--- a/Scripts/DynamicCamera.gd
+++ b/Scripts/DynamicCamera.gd
@@ -3,7 +3,7 @@ extends Camera
 onready var playerDrone = get_node("/root/Level/PlayerDrone/")
 onready var space_state = get_world().direct_space_state
 
-var MIN_OFFSET_HEIGHT = 0
+export var MIN_OFFSET_HEIGHT = 0
 export var MAX_OFFSET_HEIGHT = 4
 export var DISTANCE_FROM_DRONE = 10
 

--- a/Scripts/DynamicCamera.gd
+++ b/Scripts/DynamicCamera.gd
@@ -5,30 +5,26 @@ onready var space_state = get_world().direct_space_state
 
 var MIN_OFFSET_HEIGHT = 0
 export var MAX_OFFSET_HEIGHT = 4
-export var MAX_DOWNWARD_TILT = -60
 export var DISTANCE_FROM_DRONE = 10
 
 var offset = Vector3(0,0,DISTANCE_FROM_DRONE)
-var collision_avoidance_offset = Vector3(0,0,-0.1)
 var raycastResult
 
 func _process(delta):
 	
+	#Set the camera position to the drone's position with an offset.
+	translation = playerDrone.translation + offset
+	
 	#Cast a ray to see if there's anything in the way of the camera.
 	raycastResult = space_state.intersect_ray(playerDrone.translation, playerDrone.translation + offset, [self, playerDrone])
 	
-	#If there is something in the way, move the camera to the intersection.
+	#If there is something in the way, use the distance from the collision to interpolate a vertical offset.
 	if(raycastResult):
-		translation = raycastResult.position + collision_avoidance_offset
 		translation.y += lerp(MAX_OFFSET_HEIGHT, MIN_OFFSET_HEIGHT, (raycastResult.position.z - playerDrone.translation.z) / 10) 
-	#If not, just offset the camera from the drone's position.
+	#If not, offset the camera by the minimum value.
 	else:
-		translation = playerDrone.translation + offset
+		translation.y += MIN_OFFSET_HEIGHT
 		
-	#Then, point the camera at the drone.
+	#Finally, point the camera at the drone.
 	look_at(playerDrone.translation, Vector3(0,1,0))
-	
-	#But reel it back if the camera is tilting too far downward.
-	if(rotation_degrees.x < MAX_DOWNWARD_TILT):
-		rotation_degrees.x = MAX_DOWNWARD_TILT
 	

--- a/Scripts/Level.gd
+++ b/Scripts/Level.gd
@@ -111,7 +111,9 @@ func add_wall_to_tile(tile, direction):
 			wall.set_name("South")
 			wall.translation = Vector3(0,4.3,2.3)
 			wall.scale = northSouthScale
+			wall.get_child(0).get_child(0).visible = false; #make the mesh invisible.
 			tile.add_child(wall)
+			
 		"NONE":
 			print("Error. add_wall_to_tile requires a direction (NORTH, SOUTH, EAST, WEST).")
 			return false

--- a/Scripts/PickupCube.gd
+++ b/Scripts/PickupCube.gd
@@ -2,6 +2,11 @@ extends RigidBody
 
 var inCollider = false
 var pickedUp = false
+onready var playerPickup = get_node("/root/Level/PlayerDrone/Body/PlayerPickup")
+
+func _ready():
+	playerPickup.connect("body_entered",self,"_on_PlayerPickup_body_entered")
+	playerPickup.connect("body_exited",self,"_on_PlayerPickup_body_exited")
 
 func _process(delta):
 	if Input.is_action_just_pressed("ui_accept") && inCollider:

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ config/icon="res://icon.png"
 
 [debug]
 
+gdscript/warnings/enable=false
 settings/max_remote_stdout_chars_per_second=1874919424
 
 [rendering]


### PR DESCRIPTION
* Level.gd script updated. If the wall being added is southern, the mesh is made invisible.
* BasicWall.tscn updated so that node names are ambiguous as to the direction of the wall, since it can be used in any direction.
* DynamicCamera.gd script updated. Now, instead of moving the camera to the point of collision, it uses the distance between the drone and the collision to interpolate a vertical offset value.