### PR TITLE
Feature/toggleable recruits

### DIFF
--- a/Objects/Constructibles/RecruitSpawner/RecruitSpawner.gd
+++ b/Objects/Constructibles/RecruitSpawner/RecruitSpawner.gd
@@ -3,6 +3,7 @@ extends Spatial
 var delay = 5
 var tick = 0
 var subject_source = load("res://Objects/Recruit.tscn")
+var spawn_recruits = true
 
 func _ready():
 	print("Spawner spawned. Ready to spawn.")
@@ -10,11 +11,15 @@ func _ready():
 	
 func tick():
 	tick += 1
-	if tick == delay:
+	if tick == delay and spawn_recruits:
 		var new_subject = subject_source.instance()
 		new_subject.translation = get_global_transform().origin
 		get_tree().get_root().add_child(new_subject)
+	
+	if tick == delay:
 		tick = 0
 		
-func toggle_spawn(event):
-	if event 
+func toggle_spawn(camera, event, click_pos, click_norm, shape_idx):
+	if Input.is_action_just_pressed("click"):
+		spawn_recruits = !spawn_recruits
+		get_node("../SpotLight").light_color = Color(1,0.4,1,0) if spawn_recruits else Color(1,0.4,0.4,0)

--- a/Objects/Constructibles/RecruitSpawner/RecruitSpawner.gd
+++ b/Objects/Constructibles/RecruitSpawner/RecruitSpawner.gd
@@ -6,6 +6,7 @@ var subject_source = load("res://Objects/Recruit.tscn")
 
 func _ready():
 	print("Spawner spawned. Ready to spawn.")
+	get_node("../ToggleButton").connect("input_event",self,"toggle_spawn")
 	
 func tick():
 	tick += 1
@@ -14,3 +15,6 @@ func tick():
 		new_subject.translation = get_global_transform().origin
 		get_tree().get_root().add_child(new_subject)
 		tick = 0
+		
+func toggle_spawn(event):
+	if event 

--- a/Objects/Constructibles/RecruitSpawner/Spawner.tscn
+++ b/Objects/Constructibles/RecruitSpawner/Spawner.tscn
@@ -15,6 +15,7 @@
 
 [node name="Target" type="MeshInstance" parent="."]
 transform = Transform( 2, 0, 0, 0, 0.3, 0, 0, 0, 2, 0, 0, 0 )
+visible = false
 mesh = SubResource( 1 )
 material/0 = null
 
@@ -35,6 +36,14 @@ transform = Transform( 1.75, 0, 0, 0, 2, 0, 0, 0, 2, -4, 0, 0 )
 
 [node name="Conveyor Belt2" parent="." instance=ExtResource( 3 )]
 transform = Transform( 1.75, 0, 0, 0, 2, 0, 0, 0, 2, -8, 0, 0 )
+
+[node name="SpotLight" type="SpotLight" parent="."]
+transform = Transform( -4.37114e-008, 0.791224, 0.611527, 0, -0.611527, 0.791224, 1, 3.45855e-008, 2.67307e-008, 0, 7, 0 )
+light_color = Color( 1, 0.4, 1, 1 )
+light_energy = 16.0
+spot_range = 10.0
+spot_angle = 20.0
+spot_angle_attenuation = 3.24901
 
 [node name="ToggleButton" type="StaticBody" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 3, -4 )

--- a/Objects/Constructibles/RecruitSpawner/Spawner.tscn
+++ b/Objects/Constructibles/RecruitSpawner/Spawner.tscn
@@ -1,16 +1,20 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://Objects/Constructibles/RecruitSpawner/RecruitSpawner.gd" type="Script" id=1]
 [ext_resource path="res://Objects/Tiles/BasicTile.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Objects/Constructibles/ConveyorBelt/ConveyorBelt.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Objects/Constructibles/RecruitSpawner/ToggleButton.gd" type="Script" id=4]
 
 [sub_resource type="CubeMesh" id=1]
+
+[sub_resource type="BoxShape" id=2]
+
+[sub_resource type="CubeMesh" id=3]
 
 [node name="Spawner" type="Spatial"]
 
 [node name="Target" type="MeshInstance" parent="."]
 transform = Transform( 2, 0, 0, 0, 0.3, 0, 0, 0, 2, 0, 0, 0 )
-visible = false
 mesh = SubResource( 1 )
 material/0 = null
 
@@ -31,3 +35,15 @@ transform = Transform( 1.75, 0, 0, 0, 2, 0, 0, 0, 2, -4, 0, 0 )
 
 [node name="Conveyor Belt2" parent="." instance=ExtResource( 3 )]
 transform = Transform( 1.75, 0, 0, 0, 2, 0, 0, 0, 2, -8, 0, 0 )
+
+[node name="ToggleButton" type="StaticBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 3, -4 )
+script = ExtResource( 4 )
+
+[node name="CollisionShape" type="CollisionShape" parent="ToggleButton"]
+transform = Transform( 0.3, 0, 0, 0, 0.3, 0, 0, 0, 0.3, 0, 0, 0 )
+shape = SubResource( 2 )
+
+[node name="MeshInstance" type="MeshInstance" parent="ToggleButton/CollisionShape"]
+mesh = SubResource( 3 )
+material/0 = null

--- a/Objects/Constructibles/RecruitSpawner/ToggleButton.gd
+++ b/Objects/Constructibles/RecruitSpawner/ToggleButton.gd
@@ -1,0 +1,1 @@
+extends StaticBody

--- a/Objects/Recruit.tscn
+++ b/Objects/Recruit.tscn
@@ -7,8 +7,8 @@
 extents = Vector3( 1.14105, 3.18944, 0.440836 )
 
 [node name="Body" type="KinematicBody" groups=[
-"Recruit",
 "Subject",
+"Recruit",
 ]]
 transform = Transform( 0.7, 0, 0, 0, 0.7, 0, 0, 0, 0.7, 0, 0, 0 )
 script = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -1220,6 +1220,11 @@ clickselect_drop_item={
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+click={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
 
 [rendering]
 


### PR DESCRIPTION
You can now click an ugly floaty button to turn recruit spawning on and off. A light indicates the current status (red = no spawn, HexCorp pink = hell yea)